### PR TITLE
Fix prune command to properly handle force removal

### DIFF
--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -427,13 +427,13 @@ export class WorktreeManager {
       const { worktree } = prunable;
       console.log(chalk.gray(`Removing ${worktree.branch}...`));
       
-      const success = await GitUtils.removeWorktree(repo.path, worktree.path);
-      if (success) {
+      const result = await GitUtils.removeWorktree(repo.path, worktree.path, options.force);
+      if (result.success) {
         successCount++;
         console.log(chalk.green(`  ✅ Removed`));
       } else {
         failureCount++;
-        console.log(chalk.red(`  ❌ Failed to remove`));
+        console.log(chalk.red(`  ❌ Failed to remove: ${result.error || 'Unknown error'}`));
       }
     }
     

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -35,7 +35,7 @@ export class GitHubUtils {
         owner: githubMatch[1],
         repo: githubMatch[2]
       };
-    } catch (_) {
+    } catch {
       return null;
     }
   }


### PR DESCRIPTION
- Fix incorrect handling of removeWorktree return value in pruneWorktrees
- Pass force flag to removeWorktree when --force option is used
- Add detailed error messages when worktree removal fails
- Fix ESLint error in github.ts

🤖 Generated with [Claude Code](https://claude.ai/code)